### PR TITLE
Update links

### DIFF
--- a/text/1211-mir.md
+++ b/text/1211-mir.md
@@ -204,10 +204,9 @@ rest of the design:
 
 ### Prototype
 
-The MIR design being described here [has been prototyped][proto-crate]
-and can be viewed in the `nikomatsakis` repository on github. In
-particular, [the `repr` module][repr] defines the MIR representation,
-and [the `build` module][build] contains the code to create a MIR
+The MIR design being described can be found [here][crate]. In
+particular, [this module][mir] defines the MIR representation,
+and [this `build` module][build] contains the code to create a MIR
 representation from an AST-like form.
 
 For increased flexibility, as well as to make the code simpler, the
@@ -230,19 +229,19 @@ themselves, or else they may be additional `H::Expr` nodes. This
 allows the tree that is exported to differ in small ways from the
 actual tree within the compiler; the primary intention is to use this
 to model "adjustments" like autoderef. The code to convert from our
-current AST to the HIR is not yet complete, but it can be found in the
-[`tcx` module][tcx].
+current AST to the HIR is not yet complete, but it can be found
+[here][hair-mod].
 
 Note that the HIR mirroring system is an experiment and not really
 part of the MIR itself. It does however present an interesting option
 for (eventually) stabilizing access to the compiler's internals.
  
-[proto-crate]: https://github.com/nikomatsakis/rust/tree/mir/src/librustc_mir
-[repr]: https://github.com/nikomatsakis/rust/blob/mir/src/librustc_mir/repr.rs
-[build]: https://github.com/nikomatsakis/rust/tree/mir/src/librustc_mir/build
-[hir]: https://github.com/nikomatsakis/rust/blob/mir/src/librustc_mir/hir.rs
+[crate]: https://github.com/rust-lang/rust/blob/master/src/librustc/mir
+[mir]: https://github.com/rust-lang/rust/blob/master/src/librustc/mir/mod.rs
+[build]: https://github.com/rust-lang/rust/blob/master/src/librustc_mir/build
+[hir]: https://github.com/rust-lang/rust/blob/master/src/librustc_mir/hair
 [1191]: https://github.com/rust-lang/rfcs/pull/1191
-[tcx]: https://github.com/nikomatsakis/rust/blob/mir/src/librustc_mir/tcx/mod.rs
+[hair-mod]: https://github.com/rust-lang/rust/blob/master/src/librustc_mir/hair/mod.rs
 
 ### Overview of the MIR
 


### PR DESCRIPTION
Old links to prototypes are obsolete, should link to source instead.